### PR TITLE
feat: Add Team Assignment page and functionality

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -357,3 +357,60 @@ h2 {
   50% { transform: translateX(-10%) scale(1.05); }
   100% { transform: translateX(0) scale(1); }
 }
+
+/* Styles for team-assignment.html inputs */
+#player-inputs input[type="text"] {
+  display: block;
+  width: calc(100% - 20px); /* Adjust width as needed, considering padding */
+  padding: 10px;
+  margin-bottom: 10px;
+  border: 1px solid var(--choice-box-border, #ccc); /* Using a variable */
+  border-radius: 4px;
+  background-color: var(--bg-color, #fff); /* Using a variable */
+  color: var(--text-color, #333); /* Using a variable */
+  box-sizing: border-box;
+}
+
+.dark-mode #player-inputs input[type="text"] {
+  background-color: var(--choice-box-bg, #2c2c2c); /* Darker input background */
+  color: var(--text-color, #e0e0e0);
+  border-color: var(--choice-box-border, #444);
+}
+
+/* Styles for team-assignment.html results area */
+#team-results {
+  margin-top: 20px;
+}
+
+#team-results h3 {
+  color: var(--h2-color, #ff6347); /* Use existing variable for consistency */
+  margin-top: 15px;
+  margin-bottom: 5px;
+  border-bottom: 1px solid var(--choice-box-border, #ccc);
+  padding-bottom: 5px;
+}
+
+.dark-mode #team-results h3 {
+  color: var(--h2-color, #bb86fc);
+  border-bottom-color: var(--choice-box-border, #444);
+}
+
+#team-results ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+#team-results li {
+  background-color: var(--choice-box-bg, #f9f9f9); /* Light background for list items */
+  color: var(--text-color, #333);
+  padding: 8px 12px;
+  margin-bottom: 5px;
+  border-radius: 4px;
+  border: 1px solid var(--choice-box-border, #eee);
+}
+
+.dark-mode #team-results li {
+  background-color: var(--choice-box-bg, #2c2c2c); /* Darker list items */
+  color: var(--text-color, #e0e0e0);
+  border-color: var(--choice-box-border, #444);
+}

--- a/gift.html
+++ b/gift.html
@@ -9,6 +9,7 @@
 
 <body>
   <div style="text-align: right; padding: 10px;">
+    <a href="team-assignment.html" style="margin-right: 15px; color: var(--link-color, #e0e0e0);">チーム分け</a>
     <button id="darkModeToggle">Toggle Dark Mode</button>
   </div>
     <h1>🎉大会お疲れ様でした！🎉</h1>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <a href="index.html">大会概要</a>
     <a href="skill-selection.html">スキル選択</a>
     <a href="stage-selection.html">ステージ選択</a>
+    <a href="team-assignment.html">チーム分け</a>
     <button id="darkModeToggle">Toggle Dark Mode</button>
   </nav>
   

--- a/js/team-assignment.js
+++ b/js/team-assignment.js
@@ -1,0 +1,122 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // Constants
+  const NUM_PLAYERS_TO_INPUT = 10;
+
+  // DOM References
+  const playerInputsContainer = document.getElementById('player-inputs');
+  const assignTeamsButton = document.getElementById('assignTeamsButton');
+  const team1List = document.getElementById('team1-list');
+  const team2List = document.getElementById('team2-list');
+  const spectatorsList = document.getElementById('spectators-list');
+
+  /**
+   * Creates and appends player input fields to the DOM.
+   */
+  function createPlayerInputs() {
+    if (!playerInputsContainer) {
+      console.error('Error: Player inputs container not found!');
+      return;
+    }
+    for (let i = 0; i < NUM_PLAYERS_TO_INPUT; i++) {
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.placeholder = `プレイヤー ${i + 1}`;
+      input.id = `player-name-${i + 1}`; // Unique ID for each input
+      input.style.display = 'block'; // Basic styling for separation
+      input.style.marginBottom = '5px'; // Basic styling for separation
+      playerInputsContainer.appendChild(input);
+    }
+  }
+
+  /**
+   * Shuffles an array in place using the Fisher-Yates algorithm.
+   * @param {Array} array - The array to shuffle.
+   */
+  function shuffleArray(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [array[i], array[j]] = [array[j], array[i]]; // ES6 destructuring swap
+    }
+  }
+
+  /**
+   * Handles the team assignment logic when the button is clicked.
+   */
+  function handleTeamAssignment() {
+    if (!playerInputsContainer || !team1List || !team2List || !spectatorsList) {
+      console.error('Error: One or more DOM elements for team assignment are missing!');
+      return;
+    }
+
+    // Get Player Names
+    const inputElements = playerInputsContainer.getElementsByTagName('input');
+    const playerNames = [];
+    for (let i = 0; i < inputElements.length; i++) {
+      const name = inputElements[i].value.trim();
+      if (name) { // Only add non-empty names
+        playerNames.push(name);
+      }
+    }
+
+    // Validate Player Count
+    if (playerNames.length < 8) {
+      alert('少なくとも8名のプレイヤー名を入力してください。\n(Please enter at least 8 player names.)');
+      return;
+    }
+     if (playerNames.length > NUM_PLAYERS_TO_INPUT) {
+      alert(`プレイヤー名の入力は最大${NUM_PLAYERS_TO_INPUT}名までです。\n(Maximum of ${NUM_PLAYERS_TO_INPUT} player names can be entered.)`);
+      return;
+    }
+
+
+    // Shuffle Players
+    shuffleArray(playerNames);
+
+    // Assign to Teams and Spectators
+    // Clear previous results
+    team1List.innerHTML = '';
+    team2List.innerHTML = '';
+    spectatorsList.innerHTML = '';
+
+    const team1Players = playerNames.slice(0, 4);
+    const team2Players = playerNames.slice(4, 8);
+    const spectatorPlayers = playerNames.slice(8);
+
+    // Display Results
+    team1Players.forEach(name => {
+      const li = document.createElement('li');
+      li.textContent = name;
+      team1List.appendChild(li);
+    });
+
+    team2Players.forEach(name => {
+      const li = document.createElement('li');
+      li.textContent = name;
+      team2List.appendChild(li);
+    });
+
+    if (spectatorPlayers.length > 0) {
+      spectatorPlayers.forEach(name => {
+        const li = document.createElement('li');
+        li.textContent = name;
+        spectatorsList.appendChild(li);
+      });
+    } else {
+      // Optional: Indicate if there are no spectators
+      const li = document.createElement('li');
+      li.textContent = 'なし'; // "None"
+      // Or, hide the "観戦" h3 if desired via CSS or JS
+      spectatorsList.appendChild(li);
+    }
+  }
+
+  // Event Listener for Assign Teams Button
+  if (assignTeamsButton) {
+    assignTeamsButton.addEventListener('click', handleTeamAssignment);
+  } else {
+    console.error('Error: Assign teams button not found!');
+  }
+
+  // Initial Call to generate input fields
+  createPlayerInputs();
+});

--- a/skill-selection.html
+++ b/skill-selection.html
@@ -17,6 +17,7 @@
     <a href="index.html">大会概要</a>
     <a href="skill-selection.html">スキル選択</a>
     <a href="stage-selection.html">ステージ選択</a>
+    <a href="team-assignment.html">チーム分け</a>
     <button id="darkModeToggle">Toggle Dark Mode</button>
   </nav>
   

--- a/stage-selection.html
+++ b/stage-selection.html
@@ -17,6 +17,7 @@
     <a href="index.html">大会概要</a>
     <a href="skill-selection.html">スキル選択</a>
     <a href="stage-selection.html">ステージ選択</a>
+    <a href="team-assignment.html">チーム分け</a>
     <button id="darkModeToggle">Toggle Dark Mode</button>
   </nav>
   

--- a/team-assignment.html
+++ b/team-assignment.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>チーム分け</title>
+  <link rel="stylesheet" href="./css/styles.css?v=1.1"> <!-- Include existing stylesheet with cache buster -->
+</head>
+<body>
+  <header>
+    <h1>チーム分け</h1>
+    <p>プレイヤー名を入力してチームを分けます。</p>
+  </header>
+
+  <nav>
+    <a href="index.html">大会概要</a>
+    <a href="skill-selection.html">スキル選択</a>
+    <a href="stage-selection.html">ステージ選択</a>
+    <a href="team-assignment.html">チーム分け</a> <!-- Active link -->
+    <button id="darkModeToggle">Toggle Dark Mode</button>
+  </nav>
+  
+  <div class="container">
+    <h2>プレイヤー名入力</h2>
+    <p>8名から10名までのプレイヤー名を入力してください。</p>
+    <div id="player-inputs">
+      <!-- JavaScript will generate 10 input fields here -->
+    </div>
+    <button id="assignTeamsButton" class="random-button" style="margin-top: 20px;">チームを分ける</button>
+  </div>
+
+  <div class="container">
+    <h2>チーム結果</h2>
+    <div id="team-results">
+      <h3>チーム1</h3>
+      <ul id="team1-list"></ul>
+      <h3>チーム2</h3>
+      <ul id="team2-list"></ul>
+      <h3>観戦</h3>
+      <ul id="spectators-list"></ul>
+    </div>
+  </div>
+
+  <footer class="footer">
+    <p>&copy; 2024 ３択ロース杯運営チーム</p>
+    <a href="index.html">トップページに戻る</a>
+  </footer>  
+  
+  <script src="js/main.js" defer></script> <!-- Existing main JS for dark mode etc. -->
+  <script src="js/team-assignment.js" defer></script> <!-- New JS for this page -->
+</body>
+</html>


### PR DESCRIPTION
I've implemented a new 'Team Assignment' (チーム分け) feature for you.

Key changes:
- Created `team-assignment.html` with input fields for 8-10 player names, a button to trigger assignment, and sections to display two teams of four and any remaining spectators.
- Added a 'チーム分け' link to your main navigation bar in `index.html`, `skill-selection.html`, `stage-selection.html`, and `gift.html`.
- Created `js/team-assignment.js` to handle:
    - Dynamic generation of 10 player name input fields.
    - Collection and validation of player names.
    - Random shuffling of names using Fisher-Yates algorithm.
    - Assignment of players into two teams of four, with any additional players listed as spectators.
    - Display of team results on the page.
- Added CSS styles to `css/styles.css` for the new elements on `team-assignment.html`, ensuring consistency with your site's theme and dark mode support.
- The feature allows you to input 8-10 names, and upon clicking a button, randomly assigns them to two teams of four, with any excess (9th or 10th player) designated as spectators.